### PR TITLE
Show post titles with images and add pagination on blog page

### DIFF
--- a/index.php
+++ b/index.php
@@ -3,13 +3,32 @@
 <main class="max-w-3xl mx-auto px-4 py-12 space-y-12">
 <?php
 if ( have_posts() ) :
-	while ( have_posts() ) :
-		the_post();
-		the_title( '<h2 class="text-2xl font-semibold mb-4">', '</h2>' );
-		the_content();
-	endwhile;
+        while ( have_posts() ) :
+                the_post();
+                ?>
+                <article class="space-y-4">
+                    <?php
+                    if ( has_post_thumbnail() ) {
+                        echo '<a href="' . esc_url( get_permalink() ) . '">';
+                        the_post_thumbnail( 'large', array( 'class' => 'w-full h-auto' ) );
+                        echo '</a>';
+                    }
+                    the_title( '<h2 class="text-2xl font-semibold mb-4"><a href="' . esc_url( get_permalink() ) . '">', '</a></h2>' );
+                    ?>
+                </article>
+                <?php
+        endwhile;
+        the_posts_pagination(
+            array(
+                'mid_size'           => 2,
+                'end_size'           => 1,
+                'prev_text'          => __( '&larr; Previous Page', 'andersgoliversen' ),
+                'next_text'          => __( 'Next Page &rarr;', 'andersgoliversen' ),
+                'screen_reader_text' => '',
+            )
+        );
 else :
-	echo '<p>' . esc_html__( 'No posts found.', 'andersgoliversen' ) . '</p>';
+        echo '<p>' . esc_html__( 'No posts found.', 'andersgoliversen' ) . '</p>';
 endif;
 ?>
 </main>


### PR DESCRIPTION
## Summary
- simplify blog page posts so only featured images and titles display
- add standard WordPress pagination links

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68481b744a7c832a8a9a3a7174f9b050