### PR TITLE
Show excerpt and date on blog index

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,6 +14,10 @@ if ( have_posts() ) :
                         the_post_thumbnail( 'large', array( 'class' => 'w-full max-h-[48rem] object-cover object-center' ) );
                         echo '</a>';
                     }
+
+                    the_excerpt();
+
+                    echo '<time datetime="' . esc_attr( get_the_date( 'c' ) ) . '" class="block text-sm italic text-neutral-500">' . esc_html( get_the_date( 'F j, Y' ) ) . '</time>';
                     ?>
                 </article>
                 <?php


### PR DESCRIPTION
## Summary
- show post excerpts on the blog page
- display post publication date under the excerpt

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848634ad6d4832aa066f6cea9ddd254