### PR TITLE
Switch to round YouTube icons

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -29,8 +29,9 @@
         <a href="https://www.youtube.com/@andersgoliversen" target="_blank" rel="noopener"
            class="no-underline text-inherit decoration-transparent transition-transform duration-150 hover:scale-105 hover:text-neutral-600"
            aria-label="YouTube channel">
-            <svg viewBox="0 0 24 24" class="w-5 h-5 fill-current">
-                <path d="M23.5 6.2a2.99 2.99 0 0 0-2.1-2.1C19.4 3.5 12 3.5 12 3.5s-7.4 0-9.4.6a2.99 2.99 0 0 0-2.1 2.1A31.2 31.2 0 0 0 0 12a31.2 31.2 0 0 0 .5 5.8 2.99 2.99 0 0 0 2.1 2.1c2 .6 9.4.6 9.4.6s7.4 0 9.4-.6a2.99 2.99 0 0 0 2.1-2.1 31.2 31.2 0 0 0 .5-5.8 31.2 31.2 0 0 0-.5-5.8zM9.6 15.5v-7l6.4 3.5-6.4 3.5z"/>
+            <svg viewBox="0 0 48 48" class="w-5 h-5" aria-hidden="true">
+                <circle cx="24" cy="24" r="20" fill="#FF1A1A" class="youtube-bg" />
+                <polygon points="20,32 20,16 32,24" fill="#fff"/>
             </svg>
         </a>
     </nav>

--- a/header.php
+++ b/header.php
@@ -78,10 +78,10 @@
                         <a href="https://www.youtube.com/@andersgoliversen" target="_blank" rel="noopener"
                                 class="no-underline decoration-transparent transition-transform duration-150 hover:scale-105 group"
                                 aria-label="YouTube channel">
-                                <svg viewBox="0 0 48 48" class="w-9 h-7" aria-hidden="true">
-                                        <rect x="4" y="10" width="40" height="28" rx="8" fill="#FF1A1A" class="youtube-bg transition-colors duration-150 group-hover:fill-[#FF5252]" />
-                                        <polygon points="20,30 20,18 31,24" fill="#fff"/>
-                                </svg>
+                        <svg viewBox="0 0 48 48" class="w-6 h-6" aria-hidden="true">
+                                <circle cx="24" cy="24" r="20" fill="#FF1A1A" class="youtube-bg transition-colors duration-150 group-hover:fill-[#FF5252]" />
+                                <polygon points="20,32 20,16 32,24" fill="#fff"/>
+                        </svg>
                         </a>
                         <style>
                         a[aria-label="YouTube channel"] .youtube-bg {


### PR DESCRIPTION
## Summary
- use circular YouTube icon in the header
- update footer YouTube icon to a circle matching GitHub size

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684bfb006510832ab012944591dcee46