### PR TITLE
Fix header icon flash by specifying dimensions

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -22,14 +22,14 @@
         <a href="https://github.com/Andersgoliversen" target="_blank" rel="noopener"
            class="no-underline text-inherit decoration-transparent transition-transform duration-150 hover:scale-105 hover:text-neutral-600 active:scale-95 active:text-neutral-900 ag-interactive"
            aria-label="GitHub profile"><!-- Darken and shrink on click -->
-            <svg viewBox="0 0 16 16" class="w-5 h-5 fill-current ag-icon" aria-hidden="true">
+            <svg width="20" height="20" viewBox="0 0 16 16" class="w-5 h-5 fill-current ag-icon" aria-hidden="true">
                 <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.64 7.64 0 0 1 8 4.69c.68 0 1.36.09 2 .27 1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.014 8.014 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
             </svg>
         </a>
         <a href="https://www.youtube.com/@andersgoliversen" target="_blank" rel="noopener"
            class="no-underline text-inherit decoration-transparent transition-transform duration-150 hover:scale-105 hover:text-neutral-600 active:scale-95 active:text-neutral-900 ag-interactive"
            aria-label="YouTube channel"><!-- Darken and shrink on click -->
-            <svg viewBox="0 0 48 48" class="w-5 h-5 fill-current ag-icon" aria-hidden="true">
+            <svg width="20" height="20" viewBox="0 0 48 48" class="w-5 h-5 fill-current ag-icon" aria-hidden="true">
                 <circle cx="24" cy="24" r="24" fill="currentColor" class="youtube-bg" />
                 <polygon points="20,32 20,16 32,24" fill="#fff"/>
             </svg>

--- a/header.php
+++ b/header.php
@@ -34,9 +34,17 @@
                         <div class="flex items-center gap-2">
                                 <a href="<?php echo esc_url(home_url('/')); ?>"
                                         class="<?php echo esc_attr($logo_classes); ?> ag-interactive">
-                                        <img src="<?php echo esc_url(wp_get_attachment_image_url(8713, 'full')); ?>"
-                                                alt="<?php echo esc_attr(get_bloginfo('name') . ' - Home'); ?>"
-                                                class="h-[3em] w-auto ag-icon" />
+                                        <?php
+                                        echo wp_get_attachment_image(
+                                                8713,
+                                                'full',
+                                                false,
+                                                [
+                                                        'class' => 'h-[3em] w-auto ag-icon',
+                                                        'alt'   => get_bloginfo('name') . ' - Home',
+                                                ]
+                                        );
+                                        ?>
                                 </a>
                                 <a href="<?php echo esc_url(home_url('/')); ?>"
                                         class="<?php echo esc_attr($name_classes); ?>">
@@ -73,7 +81,7 @@
                         <a href="https://github.com/Andersgoliversen" target="_blank" rel="noopener"
                                 class="no-underline text-inherit decoration-transparent transition-transform duration-150 hover:scale-105 hover:text-neutral-600 active:scale-95 active:text-neutral-900 ag-interactive"
                                 aria-label="GitHub profile"><!-- Darken and shrink on click -->
-                                <svg viewBox="0 0 16 16" class="w-6 h-6 fill-current ag-icon" aria-hidden="true">
+                                <svg width="24" height="24" viewBox="0 0 16 16" class="w-6 h-6 fill-current ag-icon" aria-hidden="true">
                                         <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.64 7.64 0 0 1 8 4.69c.68 0 1.36.09 2 .27 1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.014 8.014 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
                                 </svg>
                         </a>
@@ -81,7 +89,7 @@
                         <a href="https://www.youtube.com/@andersgoliversen" target="_blank" rel="noopener"
                                 class="no-underline decoration-transparent transition-transform duration-150 hover:scale-105 active:scale-95 active:text-neutral-900 group header-youtube-link ag-interactive"
                                 aria-label="YouTube channel"><!-- Darken and shrink on click -->
-                                <svg viewBox="0 0 48 48" class="w-6 h-6 ag-icon" aria-hidden="true">
+                                <svg width="24" height="24" viewBox="0 0 48 48" class="w-6 h-6 ag-icon" aria-hidden="true">
                                         <circle cx="24" cy="24" r="24" fill="#FF1A1A" class="youtube-bg transition-colors duration-150" />
                                         <polygon points="20,32 20,16 34,24" fill="#fff" />
                                 </svg>

--- a/searchform.php
+++ b/searchform.php
@@ -7,7 +7,7 @@
     <input type="search" id="search-field" name="s" class="flex-grow border border-neutral-300 rounded-l px-3 py-2" placeholder="<?php esc_attr_e( 'Search …', 'andersgoliversen' ); ?>" value="<?php echo get_search_query(); ?>" />
     <button type="submit" id="search-submit" class="bg-neutral-600 text-white rounded-r px-4 py-2 transition-colors transition-transform duration-150 hover:bg-neutral-400 hover:scale-105 active:bg-neutral-700 active:scale-95 ag-interactive flex items-center justify-center"><!-- Darken and shrink when pressed -->
         <!-- Magnifying glass icon starts here -->
-        <svg class="w-5 h-5 stroke-current ag-icon" viewBox="0 0 24 24" fill="none" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <svg width="20" height="20" class="w-5 h-5 stroke-current ag-icon" viewBox="0 0 24 24" fill="none" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <!-- Magnifying glass glass (circle) -->
             <circle cx="10" cy="10" r="8" />
             <!-- Magnifying glass handle -->


### PR DESCRIPTION
## Summary
- prevent header logo from shifting layout by using `wp_get_attachment_image`
- specify width and height on SVG icons to avoid full-screen flash
- rebuild CSS assets

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685144ff0a9c832ab1e27e672c2c6c6e