### PR TITLE
Move publication date before share and related sections

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -320,3 +320,18 @@ function ag_custom_posts_pagination() {
     echo '</nav>';
 }
 
+/**
+ * Append the post date to single post content before Jetpack additions.
+ *
+ * @param string $content The post content.
+ * @return string Modified content with publication date appended.
+ */
+function ag_append_post_date( $content ) {
+    if ( is_single() && in_the_loop() && is_main_query() ) {
+        $date = '<time datetime="' . esc_attr( get_the_date( 'c' ) ) . '" class="block text-sm italic text-neutral-500">' . esc_html( get_the_date( 'F j, Y' ) ) . '</time>';
+        $content .= $date;
+    }
+    return $content;
+}
+add_filter( 'the_content', 'ag_append_post_date', 18 );
+

--- a/single.php
+++ b/single.php
@@ -6,7 +6,6 @@
             the_post();
             the_title( '<h1 class="text-3xl font-semibold mb-4">', '</h1>' );
             the_content();
-            echo '<time datetime="' . esc_attr( get_the_date( 'c' ) ) . '" class="block text-sm italic text-neutral-500">' . esc_html( get_the_date( 'F j, Y' ) ) . '</time>';
         endwhile;
     endif;
     ?>


### PR DESCRIPTION
## Summary
- move post date output from single.php into a filter
- append publication date right after content but before Jetpack additions

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852db285b90832ab89eaabbf7b54ace